### PR TITLE
Fix the test failure by mocking inline-style-prefixer

### DIFF
--- a/__mocks__/inline-style-prefixer.js
+++ b/__mocks__/inline-style-prefixer.js
@@ -1,0 +1,5 @@
+'use strict';
+
+let mock = jest.genMockFromModule('inline-style-prefixer');
+
+module.exports = mock;


### PR DESCRIPTION
Test of Jest has [failed](https://travis-ci.org/ukatama/material-ui-skeleton/builds/90776189) by Material UI updates.
